### PR TITLE
feat(site): replace static screenshot with interactive app showcase

### DIFF
--- a/site/css/animations.css
+++ b/site/css/animations.css
@@ -1,8 +1,8 @@
 /* Scroll fade-up reveal */
 .fade-up {
   opacity: 0;
-  transform: translateY(24px);
-  transition: opacity var(--ease-slow), transform var(--ease-slow);
+  transform: translateY(28px);
+  transition: opacity var(--ease-spring), transform var(--ease-spring);
 }
 
 .fade-up.visible {
@@ -11,47 +11,76 @@
 }
 
 /* Stagger delays */
-.fade-up[data-delay="1"] { transition-delay: 100ms; }
-.fade-up[data-delay="2"] { transition-delay: 200ms; }
-.fade-up[data-delay="3"] { transition-delay: 300ms; }
-.fade-up[data-delay="4"] { transition-delay: 400ms; }
-.fade-up[data-delay="5"] { transition-delay: 500ms; }
+.fade-up[data-delay="1"] { transition-delay: 80ms; }
+.fade-up[data-delay="2"] { transition-delay: 160ms; }
+.fade-up[data-delay="3"] { transition-delay: 240ms; }
+.fade-up[data-delay="4"] { transition-delay: 320ms; }
+.fade-up[data-delay="5"] { transition-delay: 400ms; }
 
 /* Waveform bars */
 @keyframes wave-pulse {
-  0%, 100% { transform: scaleY(0.3); opacity: 0.3; }
-  50%      { transform: scaleY(1);   opacity: 1; }
+  0%, 100% { transform: scaleY(0.25); opacity: 0.25; }
+  50%      { transform: scaleY(1);    opacity: 0.8; }
 }
 
 .hero-waveform {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
-  height: 52px;
-  margin-bottom: var(--sp-10);
+  gap: 5px;
+  height: 36px;
+  margin-bottom: var(--sp-8);
 }
 
 .wave-bar {
-  width: 3px;
+  width: 2.5px;
   background: var(--accent);
   border-radius: var(--radius-full);
-  animation: wave-pulse 1.8s ease-in-out infinite;
+  animation: wave-pulse 2s ease-in-out infinite;
   transform-origin: center;
 }
 
-.wave-bar:nth-child(1)  { height: 16px; animation-delay: 0s; }
-.wave-bar:nth-child(2)  { height: 24px; animation-delay: 0.1s; }
-.wave-bar:nth-child(3)  { height: 32px; animation-delay: 0.2s; }
-.wave-bar:nth-child(4)  { height: 40px; animation-delay: 0.3s; }
-.wave-bar:nth-child(5)  { height: 48px; animation-delay: 0.4s; }
-.wave-bar:nth-child(6)  { height: 52px; animation-delay: 0.5s; }
-.wave-bar:nth-child(7)  { height: 52px; animation-delay: 0.6s; }
-.wave-bar:nth-child(8)  { height: 48px; animation-delay: 0.7s; }
-.wave-bar:nth-child(9)  { height: 40px; animation-delay: 0.8s; }
-.wave-bar:nth-child(10) { height: 32px; animation-delay: 0.9s; }
-.wave-bar:nth-child(11) { height: 24px; animation-delay: 1.0s; }
-.wave-bar:nth-child(12) { height: 16px; animation-delay: 1.1s; }
+.wave-bar:nth-child(1)  { height: 10px; animation-delay: 0s; }
+.wave-bar:nth-child(2)  { height: 16px; animation-delay: 0.12s; }
+.wave-bar:nth-child(3)  { height: 24px; animation-delay: 0.24s; }
+.wave-bar:nth-child(4)  { height: 30px; animation-delay: 0.36s; }
+.wave-bar:nth-child(5)  { height: 36px; animation-delay: 0.48s; }
+.wave-bar:nth-child(6)  { height: 36px; animation-delay: 0.60s; }
+.wave-bar:nth-child(7)  { height: 30px; animation-delay: 0.72s; }
+.wave-bar:nth-child(8)  { height: 24px; animation-delay: 0.84s; }
+.wave-bar:nth-child(9)  { height: 16px; animation-delay: 0.96s; }
+.wave-bar:nth-child(10) { height: 10px; animation-delay: 1.08s; }
+
+/* Floating animation for overlay pill */
+@keyframes float {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(-6px); }
+}
+
+.sc-pill-wrap {
+  animation: float 4s ease-in-out infinite;
+}
+
+/* Gentle glow pulse behind app showcase */
+@keyframes glow-breathe {
+  0%, 100% { opacity: 0.5; }
+  50%      { opacity: 1; }
+}
+
+.sc-glow {
+  animation: glow-breathe 6s ease-in-out infinite;
+}
+
+/* Record button pulse */
+@keyframes rec-pulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.5; }
+}
+
+.sc-pill-rec-inner,
+.sc-rail-record-dot {
+  animation: rec-pulse 1.8s ease-in-out infinite;
+}
 
 /* Respect reduced motion */
 @media (prefers-reduced-motion: reduce) {
@@ -63,7 +92,14 @@
 
   .wave-bar {
     animation: none;
-    opacity: 0.5;
-    transform: scaleY(0.6);
+    opacity: 0.4;
+    transform: scaleY(0.5);
+  }
+
+  .sc-pill-wrap,
+  .sc-glow,
+  .sc-pill-rec-inner,
+  .sc-rail-record-dot {
+    animation: none;
   }
 }

--- a/site/css/base.css
+++ b/site/css/base.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400;12..96,600;12..96,700;12..96,800&family=Outfit:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500&display=swap');
 
 *,
 *::before,
@@ -13,13 +13,53 @@ html {
   -webkit-text-size-adjust: 100%;
 }
 
+/* Slim custom scrollbars */
+.sc-sidebar-scroll,
+.sc-main {
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
+.sc-sidebar-scroll::-webkit-scrollbar,
+.sc-main::-webkit-scrollbar {
+  width: 4px;
+}
+
+.sc-sidebar-scroll::-webkit-scrollbar-track,
+.sc-main::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.sc-sidebar-scroll::-webkit-scrollbar-thumb,
+.sc-main::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 4px;
+}
+
+.sc-sidebar-scroll::-webkit-scrollbar-thumb:hover,
+.sc-main::-webkit-scrollbar-thumb:hover {
+  background: var(--text-muted);
+}
+
 body {
-  font-family: var(--font);
+  font-family: var(--font-body);
   background: var(--bg);
   color: var(--text);
   line-height: var(--leading-normal);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+/* Film grain overlay */
+body::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: var(--z-grain);
+  opacity: 0.028;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  background-size: 200px 200px;
 }
 
 img {
@@ -31,6 +71,12 @@ img {
 a {
   color: inherit;
   text-decoration: none;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-display);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
 }
 
 /* Container */
@@ -46,18 +92,20 @@ a {
 }
 
 .section-label {
-  font-size: var(--text-sm);
-  font-weight: var(--weight-semibold);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
   color: var(--accent);
   text-transform: uppercase;
-  letter-spacing: var(--tracking-wide);
-  margin-bottom: var(--sp-3);
+  letter-spacing: var(--tracking-wider);
+  margin-bottom: var(--sp-4);
 }
 
 .section-headline {
-  font-size: var(--text-3xl);
-  font-weight: var(--weight-bold);
-  letter-spacing: var(--tracking-tight);
+  font-family: var(--font-display);
+  font-size: var(--text-4xl);
+  font-weight: var(--weight-extrabold);
+  letter-spacing: -0.03em;
   line-height: var(--leading-tight);
   margin-bottom: var(--sp-4);
 }
@@ -66,6 +114,7 @@ a {
   font-size: var(--text-lg);
   color: var(--text-secondary);
   margin-bottom: var(--sp-12);
+  max-width: 540px;
 }
 
 /* Buttons */
@@ -74,27 +123,27 @@ a {
   align-items: center;
   justify-content: center;
   gap: var(--sp-2);
-  font-family: var(--font);
+  font-family: var(--font-body);
   font-weight: var(--weight-medium);
   text-decoration: none;
   border: none;
   cursor: pointer;
   transition: all var(--ease-base);
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-full);
 }
 
 .btn-sm {
-  padding: 8px 16px;
+  padding: 8px 18px;
   font-size: var(--text-sm);
 }
 
 .btn-md {
-  padding: 10px 22px;
+  padding: 10px 24px;
   font-size: var(--text-base);
 }
 
 .btn-lg {
-  padding: 14px 28px;
+  padding: 14px 32px;
   font-size: var(--text-base);
 }
 
@@ -106,16 +155,18 @@ a {
 .btn-primary:hover {
   background: var(--accent-dim);
   color: #fff;
+  box-shadow: 0 0 24px var(--accent-glow-strong);
 }
 
 .btn-ghost {
   background: transparent;
-  color: var(--text);
+  color: var(--text-secondary);
   border: 1px solid var(--border);
 }
 
 .btn-ghost:hover {
   border-color: var(--text-tertiary);
+  color: var(--text);
   background: var(--bg-elevated);
 }
 
@@ -124,9 +175,9 @@ a {
   position: sticky;
   top: 0;
   z-index: var(--z-nav);
-  background: rgba(10, 10, 10, 0.8);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
+  background: rgba(11, 11, 9, 0.75);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
   border-bottom: 1px solid transparent;
   transition: border-color var(--ease-base);
 }
@@ -146,7 +197,8 @@ a {
   display: flex;
   align-items: center;
   gap: var(--sp-3);
-  font-weight: var(--weight-semibold);
+  font-family: var(--font-display);
+  font-weight: var(--weight-bold);
   font-size: var(--text-base);
   color: var(--text);
   flex-shrink: 0;
@@ -167,15 +219,11 @@ a {
 
 .nav-links a {
   font-size: var(--text-sm);
-  color: var(--text-secondary);
+  color: var(--text-tertiary);
   transition: color var(--ease-fast);
 }
 
 .nav-links a:hover {
-  color: var(--text);
-}
-
-.nav-links a.active {
   color: var(--text);
 }
 
@@ -216,7 +264,7 @@ a {
 
 /* Footer */
 .footer {
-  padding: var(--sp-10) 0;
+  padding: var(--sp-12) 0;
   border-top: 1px solid var(--border);
 }
 
@@ -232,6 +280,7 @@ a {
   display: flex;
   align-items: center;
   gap: var(--sp-2);
+  font-family: var(--font-display);
   font-weight: var(--weight-semibold);
   font-size: var(--text-sm);
 }
@@ -249,7 +298,7 @@ a {
 
 .footer-links a {
   font-size: var(--text-sm);
-  color: var(--text-secondary);
+  color: var(--text-tertiary);
   transition: color var(--ease-fast);
 }
 
@@ -259,7 +308,7 @@ a {
 
 .footer-copy {
   font-size: var(--text-xs);
-  color: var(--text-tertiary);
+  color: var(--text-muted);
 }
 
 /* Responsive */
@@ -287,9 +336,9 @@ a {
     left: 0;
     right: 0;
     flex-direction: column;
-    background: rgba(10, 10, 10, 0.95);
-    backdrop-filter: blur(16px);
-    -webkit-backdrop-filter: blur(16px);
+    background: rgba(11, 11, 9, 0.95);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
     padding: var(--sp-6);
     gap: var(--sp-4);
     border-bottom: 1px solid var(--border);
@@ -312,7 +361,6 @@ a {
     display: flex;
   }
 
-  /* Footer */
   .footer-inner {
     flex-direction: column;
     align-items: center;

--- a/site/css/landing.css
+++ b/site/css/landing.css
@@ -1,23 +1,31 @@
-/* Hero */
+/* ================================================================
+   HERO
+   ================================================================ */
 .hero {
   text-align: center;
-  padding: var(--sp-32) 0 var(--sp-24);
+  padding: var(--sp-24) 0 var(--sp-16);
+  overflow: hidden;
 }
 
 .hero-title {
+  font-family: var(--font-display);
   font-size: var(--text-5xl);
-  font-weight: var(--weight-bold);
-  letter-spacing: var(--tracking-tight);
-  line-height: var(--leading-tight);
+  font-weight: var(--weight-extrabold);
+  letter-spacing: -0.035em;
+  line-height: 1.08;
   margin-bottom: var(--sp-6);
+  max-width: 700px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .hero-subtitle {
   font-size: var(--text-lg);
   color: var(--text-secondary);
-  max-width: 520px;
+  max-width: 500px;
   margin: 0 auto var(--sp-10);
   line-height: var(--leading-relaxed);
+  font-weight: var(--weight-light);
 }
 
 .hero-actions {
@@ -25,60 +33,579 @@
   gap: var(--sp-4);
   justify-content: center;
   flex-wrap: wrap;
-  margin-bottom: var(--sp-8);
+  margin-bottom: var(--sp-6);
 }
 
 .hero-platforms {
   font-size: var(--text-sm);
+  color: var(--text-muted);
+  margin-bottom: var(--sp-16);
+}
+
+/* ── Interactive Showcase ── */
+.hero-showcase {
+  position: relative;
+  max-width: 940px;
+  margin: 0 auto;
+}
+
+.sc-glow {
+  position: absolute;
+  inset: 15% 10%;
+  background: radial-gradient(ellipse at center, var(--accent-glow-strong) 0%, transparent 70%);
+  filter: blur(80px);
+  z-index: 0;
+  pointer-events: none;
+}
+
+/* ── App Frame ── */
+.sc-app {
+  position: relative;
+  z-index: 1;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  overflow: hidden;
+  background: var(--bg);
+  box-shadow:
+    0 2px 8px rgba(0,0,0,0.3),
+    0 16px 64px rgba(0,0,0,0.5),
+    0 32px 100px rgba(0,0,0,0.3);
+}
+
+/* Title bar */
+.sc-titlebar {
+  height: 36px;
+  display: flex;
+  align-items: center;
+  padding: 0 14px;
+  background: var(--bg-elevated);
+  border-bottom: 1px solid var(--border-subtle);
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.sc-dots {
+  display: flex;
+  gap: 7px;
+}
+
+.sc-dot {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+}
+
+.sc-dot--close { background: #ff5f57; }
+.sc-dot--min   { background: #febc2e; }
+.sc-dot--max   { background: #28c840; }
+
+/* Body: 3-column layout */
+.sc-body {
+  display: grid;
+  grid-template-columns: 48px 220px 1fr;
+  height: 420px;
+}
+
+/* ── Icon Rail ── */
+.sc-rail {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 0;
+  background: var(--bg);
+  border-right: 1px solid var(--border-subtle);
+}
+
+.sc-rail-top,
+.sc-rail-bottom {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.sc-rail-logo {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-sm);
+  margin-bottom: 8px;
+}
+
+.sc-rail-btn {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-sm);
+  border: none;
+  background: transparent;
+  color: var(--text-tertiary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: color var(--ease-fast), background var(--ease-fast);
+}
+
+.sc-rail-btn svg {
+  width: 18px;
+  height: 18px;
+}
+
+.sc-rail-btn:hover {
+  color: var(--text);
+  background: var(--bg-card);
+}
+
+.sc-rail-btn--active {
+  color: var(--accent);
+  background: var(--accent-glow);
+}
+
+.sc-rail-btn--active:hover {
+  color: var(--accent);
+}
+
+.sc-rail-record {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: rgba(239, 68, 68, 0.12);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background var(--ease-fast);
+}
+
+.sc-rail-record:hover {
+  background: rgba(239, 68, 68, 0.2);
+}
+
+.sc-rail-record-dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #ef4444;
+}
+
+/* ── Sidebar ── */
+.sc-sidebar {
+  background: var(--bg-elevated);
+  border-right: 1px solid var(--border-subtle);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+}
+
+.sc-sidebar-header {
+  font-family: var(--font-display);
+  font-weight: var(--weight-bold);
+  font-size: var(--text-sm);
+  padding: 14px 16px 10px;
+  color: var(--text);
+  text-align: left;
+}
+
+.sc-sidebar-scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 8px 12px;
+}
+
+.sc-group-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wider);
+  padding: 12px 8px 4px;
+}
+
+.sc-meeting {
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background var(--ease-fast);
+  margin-bottom: 2px;
+}
+
+.sc-meeting:hover {
+  background: var(--bg-card);
+}
+
+.sc-meeting--active {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+}
+
+.sc-meeting-title {
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--text);
+  line-height: 1.3;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sc-meeting-sub {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sc-meeting-dur {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-muted);
+  margin-top: 3px;
+}
+
+/* ── Main Panel ── */
+.sc-main {
+  background: var(--bg);
+  padding: 20px 24px;
+  overflow-y: auto;
+  text-align: left;
+}
+
+.sc-detail-title {
+  font-family: var(--font-display);
+  font-size: var(--text-xl);
+  font-weight: var(--weight-bold);
+  color: var(--text);
+  margin-bottom: 2px;
+}
+
+.sc-detail-sub {
+  font-size: var(--text-sm);
+  color: var(--text-tertiary);
+  margin-bottom: 12px;
+}
+
+.sc-detail-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-bottom: 16px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.sc-detail-meta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12px;
   color: var(--text-tertiary);
 }
 
-/* How it works — Steps */
+.sc-detail-meta span strong {
+  color: var(--text-secondary);
+  font-weight: var(--weight-medium);
+}
+
+.sc-detail-meta svg {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+/* ── Tabs ── */
+.sc-tabs {
+  display: flex;
+  gap: 2px;
+  border-bottom: 1px solid var(--border-subtle);
+  margin-bottom: 16px;
+}
+
+.sc-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 8px 12px;
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: var(--weight-medium);
+  color: var(--text-tertiary);
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition: color var(--ease-fast), border-color var(--ease-fast);
+  margin-bottom: -1px;
+}
+
+.sc-tab svg {
+  width: 14px;
+  height: 14px;
+}
+
+.sc-tab:hover {
+  color: var(--text-secondary);
+}
+
+.sc-tab--active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* ── Panels ── */
+.sc-panel {
+  min-height: 200px;
+}
+
+.sc-section-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wider);
+  margin-bottom: 8px;
+}
+
+.sc-overview {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  line-height: var(--leading-normal);
+  margin-bottom: 20px;
+}
+
+.sc-key-points,
+.sc-decisions {
+  list-style: none;
+  margin-bottom: 20px;
+}
+
+.sc-key-points li,
+.sc-decisions li {
+  position: relative;
+  padding-left: 16px;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+
+.sc-key-points li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 9px;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
+.sc-decisions li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 9px;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--text-muted);
+}
+
+/* Action Items */
+.sc-action-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.sc-action-item:last-child {
+  border-bottom: none;
+}
+
+.sc-action-checkbox {
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  border: 1.5px solid var(--text-muted);
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.sc-action-text {
+  flex: 1;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.sc-action-assignee {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--accent);
+  background: var(--accent-glow);
+  padding: 2px 8px;
+  border-radius: var(--radius-full);
+  white-space: nowrap;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+/* Transcript */
+.sc-transcript-line {
+  display: grid;
+  grid-template-columns: 60px 56px 1fr;
+  gap: 8px;
+  padding: 7px 0;
+  border-bottom: 1px solid var(--border-subtle);
+  align-items: baseline;
+}
+
+.sc-transcript-line:last-child {
+  border-bottom: none;
+}
+
+.sc-ts {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.sc-speaker {
+  font-family: var(--font-body);
+  font-size: 12px;
+  font-weight: var(--weight-semibold);
+  color: var(--accent);
+}
+
+.sc-text {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+/* ── Overlay Pill ── */
+.sc-pill-wrap {
+  position: absolute;
+  bottom: -28px;
+  right: 8%;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.sc-pill {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 10px 6px 6px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  box-shadow:
+    0 4px 16px rgba(0,0,0,0.5),
+    0 12px 40px rgba(0,0,0,0.3);
+}
+
+.sc-pill-logo {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+}
+
+.sc-pill-icon {
+  color: var(--text-tertiary);
+  display: flex;
+  align-items: center;
+}
+
+.sc-pill-icon svg {
+  width: 16px;
+  height: 16px;
+}
+
+.sc-pill-rec {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: rgba(239, 68, 68, 0.15);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.sc-pill-rec-inner {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #ef4444;
+}
+
+.sc-pill-tag {
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  letter-spacing: var(--tracking-wide);
+  white-space: nowrap;
+}
+
+.sc-pill-tag::before {
+  content: '';
+  display: inline-block;
+  width: 20px;
+  height: 1px;
+  background: var(--border);
+  vertical-align: middle;
+  margin-right: 8px;
+}
+
+/* ================================================================
+   HOW IT WORKS — Steps
+   ================================================================ */
 .steps-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: var(--sp-6);
+  gap: var(--sp-1);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--border);
 }
 
 .step-card {
   background: var(--bg-card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
   padding: var(--sp-8) var(--sp-6);
-  text-align: center;
-  transition: border-color var(--ease-base);
+  text-align: left;
+  position: relative;
+  transition: background var(--ease-base);
 }
 
 .step-card:hover {
-  border-color: var(--border-subtle);
-}
-
-.step-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 48px;
-  height: 48px;
-  margin: 0 auto var(--sp-4);
-  color: var(--accent);
-}
-
-.step-icon svg {
-  width: 28px;
-  height: 28px;
+  background: var(--bg-card-hover);
 }
 
 .step-number {
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
-  color: var(--accent);
-  margin-bottom: var(--sp-3);
-  letter-spacing: var(--tracking-wide);
+  font-family: var(--font-display);
+  font-size: var(--text-4xl);
+  font-weight: var(--weight-extrabold);
+  color: var(--border);
+  line-height: 1;
+  margin-bottom: var(--sp-6);
+  letter-spacing: -0.04em;
+}
+
+.step-card:hover .step-number {
+  color: var(--accent-glow-strong);
 }
 
 .step-card h3 {
+  font-family: var(--font-display);
   font-size: var(--text-lg);
-  font-weight: var(--weight-semibold);
+  font-weight: var(--weight-bold);
   margin-bottom: var(--sp-2);
 }
 
@@ -88,10 +615,12 @@
   line-height: var(--leading-normal);
 }
 
-/* Features Grid */
+/* ================================================================
+   FEATURES — 2-column grid
+   ================================================================ */
 .features-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: 1fr 1fr;
   gap: var(--sp-5);
 }
 
@@ -99,34 +628,29 @@
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
-  padding: var(--sp-6);
+  padding: var(--sp-8) var(--sp-6);
   transition: border-color var(--ease-base), box-shadow var(--ease-base);
+  position: relative;
 }
 
 .feature-card:hover {
-  border-color: var(--accent);
+  border-color: var(--accent-dim);
   box-shadow: var(--shadow-glow);
 }
 
-.feature-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 40px;
-  height: 40px;
+.feature-number {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  letter-spacing: var(--tracking-wider);
   margin-bottom: var(--sp-4);
-  color: var(--accent);
-}
-
-.feature-icon svg {
-  width: 24px;
-  height: 24px;
 }
 
 .feature-card h3 {
-  font-size: var(--text-base);
-  font-weight: var(--weight-semibold);
-  margin-bottom: var(--sp-2);
+  font-family: var(--font-display);
+  font-size: var(--text-xl);
+  font-weight: var(--weight-bold);
+  margin-bottom: var(--sp-3);
 }
 
 .feature-card p {
@@ -135,7 +659,9 @@
   line-height: var(--leading-normal);
 }
 
-/* Privacy Cards */
+/* ================================================================
+   PRIVACY / PROCESSING CARDS
+   ================================================================ */
 .privacy-cards {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
@@ -159,17 +685,19 @@
   position: absolute;
   top: var(--sp-4);
   right: var(--sp-4);
-  font-size: var(--text-xs);
-  font-weight: var(--weight-semibold);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: var(--weight-medium);
   color: var(--accent);
   background: var(--accent-glow);
   padding: 4px 10px;
   border-radius: var(--radius-full);
-  letter-spacing: var(--tracking-wide);
+  letter-spacing: var(--tracking-wider);
   text-transform: uppercase;
 }
 
 .privacy-card h3 {
+  font-family: var(--font-display);
   font-size: var(--text-xl);
   font-weight: var(--weight-bold);
   margin-bottom: var(--sp-6);
@@ -182,10 +710,11 @@
 }
 
 .privacy-card dt {
-  font-size: var(--text-xs);
-  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-muted);
   text-transform: uppercase;
-  letter-spacing: var(--tracking-wide);
+  letter-spacing: var(--tracking-wider);
 }
 
 .privacy-card dd {
@@ -196,77 +725,28 @@
 
 .highlight-green {
   color: var(--success);
-  font-weight: var(--weight-semibold);
+  font-weight: var(--weight-medium);
 }
 
 .highlight-yellow {
   color: var(--warning);
 }
 
-.highlight-red {
-  color: var(--danger);
-}
-
-/* Comparison Table */
-.table-wrapper {
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-}
-
-.comparison-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: var(--text-sm);
-}
-
-.comparison-table th,
-.comparison-table td {
-  padding: var(--sp-3) var(--sp-5);
-  text-align: left;
-  border-bottom: 1px solid var(--border);
-}
-
-.comparison-table thead th {
-  font-weight: var(--weight-semibold);
-  color: var(--text-tertiary);
-  font-size: var(--text-xs);
-  text-transform: uppercase;
-  letter-spacing: var(--tracking-wide);
-  background: var(--bg-elevated);
-}
-
-.comparison-table thead th.highlight {
-  color: var(--accent);
-  background: var(--accent-glow);
-}
-
-.comparison-table tbody tr:last-child td {
-  border-bottom: none;
-}
-
-.comparison-table tbody td:first-child {
-  font-weight: var(--weight-medium);
-  color: var(--text);
-}
-
-.comparison-table .check {
-  color: var(--success);
-}
-
-.comparison-table .cross {
-  color: var(--text-muted);
-}
-
-.comparison-table .partial {
-  color: var(--warning);
-}
-
-/* Download CTA */
+/* ================================================================
+   DOWNLOAD CTA
+   ================================================================ */
 .section--cta {
   text-align: center;
   border-top: 1px solid var(--border);
+}
+
+.section--cta .section-headline {
+  font-size: var(--text-4xl);
+}
+
+.section--cta .section-subtitle {
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .download-grid {
@@ -274,7 +754,7 @@
   gap: var(--sp-4);
   justify-content: center;
   flex-wrap: wrap;
-  margin-bottom: var(--sp-8);
+  margin-bottom: var(--sp-6);
 }
 
 .download-card {
@@ -282,39 +762,46 @@
   flex-direction: column;
   align-items: center;
   gap: var(--sp-3);
-  padding: var(--sp-8) var(--sp-10);
+  padding: var(--sp-6) var(--sp-8);
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
-  transition: border-color var(--ease-base), box-shadow var(--ease-base);
-  min-width: 160px;
+  transition: border-color var(--ease-base), box-shadow var(--ease-base), transform var(--ease-base);
+  min-width: 150px;
 }
 
 .download-card:hover {
   border-color: var(--accent);
   box-shadow: var(--shadow-glow);
+  transform: translateY(-2px);
 }
 
 .download-card svg {
-  width: 32px;
-  height: 32px;
+  width: 28px;
+  height: 28px;
+  color: var(--text-secondary);
+}
+
+.download-card:hover svg {
   color: var(--text);
 }
 
 .download-platform {
+  font-family: var(--font-display);
   font-weight: var(--weight-semibold);
-  font-size: var(--text-base);
+  font-size: var(--text-sm);
 }
 
 .download-ext {
   font-family: var(--font-mono);
-  font-size: var(--text-xs);
-  color: var(--text-tertiary);
+  font-size: 11px;
+  color: var(--text-muted);
 }
 
 .download-note {
   font-size: var(--text-sm);
   color: var(--text-tertiary);
+  margin-bottom: var(--sp-8);
 }
 
 .download-note a {
@@ -327,16 +814,26 @@
   color: var(--text);
 }
 
-/* Responsive */
+/* Roadmap link */
+.roadmap-cta {
+  display: flex;
+  gap: var(--sp-4);
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+/* ================================================================
+   RESPONSIVE
+   ================================================================ */
 @media (max-width: 1024px) {
-  .features-grid {
-    grid-template-columns: repeat(2, 1fr);
+  .hero-title {
+    font-size: var(--text-4xl);
   }
 }
 
 @media (max-width: 768px) {
   .hero {
-    padding: var(--sp-20) 0 var(--sp-16);
+    padding: var(--sp-16) 0 var(--sp-10);
   }
 
   .hero-title {
@@ -347,8 +844,58 @@
     font-size: var(--text-base);
   }
 
-  .steps-grid,
-  .features-grid,
+  .hero-showcase {
+    max-width: 100%;
+  }
+
+  /* Showcase: hide sidebar, collapse to single column */
+  .sc-body {
+    grid-template-columns: 40px 1fr;
+    height: 340px;
+  }
+
+  .sc-sidebar {
+    display: none;
+  }
+
+  .sc-main {
+    padding: 14px 16px;
+  }
+
+  .sc-detail-title {
+    font-size: var(--text-lg);
+  }
+
+  .sc-detail-meta {
+    gap: 8px;
+  }
+
+  .sc-detail-meta span {
+    font-size: 11px;
+  }
+
+  .sc-transcript-line {
+    grid-template-columns: 50px 44px 1fr;
+    gap: 4px;
+  }
+
+  .sc-pill-wrap {
+    bottom: -20px;
+    right: 4%;
+  }
+
+  .sc-pill-tag {
+    display: none;
+  }
+
+  .steps-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .features-grid {
+    grid-template-columns: 1fr;
+  }
+
   .privacy-cards {
     grid-template-columns: 1fr;
   }
@@ -360,6 +907,6 @@
 
   .download-card {
     width: 100%;
-    max-width: 280px;
+    max-width: 260px;
   }
 }

--- a/site/css/tokens.css
+++ b/site/css/tokens.css
@@ -1,26 +1,27 @@
 :root {
-  /* Background */
-  --bg: #0a0a0a;
-  --bg-elevated: #141414;
-  --bg-card: #1a1a1a;
-  --bg-card-hover: #222222;
-  --surface: #0f0f0f;
+  /* Background — warm charcoal */
+  --bg: #0b0b09;
+  --bg-elevated: #131311;
+  --bg-card: #191916;
+  --bg-card-hover: #1f1f1c;
+  --surface: #0f0f0d;
 
-  /* Text */
-  --text: #f0f0f0;
-  --text-secondary: #a0a0a0;
-  --text-tertiary: #666666;
-  --text-muted: #444444;
+  /* Text — warm whites */
+  --text: #ece9e1;
+  --text-secondary: #9a9789;
+  --text-tertiary: #5c5a51;
+  --text-muted: #3d3b35;
 
-  /* Accent — olive green from logo */
+  /* Accent — olive/sage from logo */
   --accent: #9ab04d;
-  --accent-dim: #7a8c34;
-  --accent-glow: rgba(154, 176, 77, 0.12);
-  --accent-text: #0a0a0a;
+  --accent-dim: #7d8f3d;
+  --accent-glow: rgba(154, 176, 77, 0.08);
+  --accent-glow-strong: rgba(154, 176, 77, 0.18);
+  --accent-text: #0b0b09;
 
   /* Borders */
-  --border: #1f1f1f;
-  --border-subtle: #181818;
+  --border: #242420;
+  --border-subtle: #1c1c19;
 
   /* Semantic */
   --success: #4ade80;
@@ -28,7 +29,9 @@
   --danger: #f87171;
 
   /* Typography */
-  --font: 'Inter', system-ui, -apple-system, sans-serif;
+  --font-display: 'Bricolage Grotesque', system-ui, sans-serif;
+  --font-body: 'Outfit', system-ui, sans-serif;
+  --font: var(--font-body);
   --font-mono: 'JetBrains Mono', 'SF Mono', 'Fira Code', monospace;
 
   --text-xs: 0.75rem;
@@ -38,21 +41,26 @@
   --text-xl: 1.25rem;
   --text-2xl: 1.5rem;
   --text-3xl: 2rem;
-  --text-4xl: 2.5rem;
-  --text-5xl: 3.5rem;
+  --text-4xl: 2.75rem;
+  --text-5xl: 3.75rem;
+  --text-6xl: 4.5rem;
 
+  --weight-light: 300;
   --weight-normal: 400;
   --weight-medium: 500;
   --weight-semibold: 600;
   --weight-bold: 700;
+  --weight-extrabold: 800;
 
-  --leading-tight: 1.2;
+  --leading-tight: 1.1;
+  --leading-snug: 1.25;
   --leading-normal: 1.6;
   --leading-relaxed: 1.8;
 
-  --tracking-tight: -0.02em;
+  --tracking-tight: -0.025em;
   --tracking-normal: 0;
-  --tracking-wide: 0.05em;
+  --tracking-wide: 0.06em;
+  --tracking-wider: 0.1em;
 
   /* Spacing */
   --sp-1: 0.25rem;
@@ -86,16 +94,19 @@
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
   --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
+  --shadow-xl: 0 24px 80px rgba(0, 0, 0, 0.6);
   --shadow-glow: 0 0 40px var(--accent-glow);
 
   /* Transitions */
   --ease-fast: 150ms ease;
   --ease-base: 300ms ease;
   --ease-slow: 500ms ease;
+  --ease-spring: 600ms cubic-bezier(0.16, 1, 0.3, 1);
 
   /* Z-index */
   --z-base: 1;
   --z-nav: 100;
   --z-overlay: 200;
   --z-modal: 300;
+  --z-grain: 9999;
 }

--- a/site/index.html
+++ b/site/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Frajola — Local meeting recorder with guided onboarding</title>
-  <meta name="description" content="Privacy-first meeting recorder with local Whisper transcription, optional AI summaries, floating overlay controls, and first-run onboarding.">
+  <title>Frajola — Privacy-first meeting recorder</title>
+  <meta name="description" content="Record meetings locally with Whisper transcription and AI summaries. No bots, no cloud, no account required.">
   <link rel="icon" type="image/png" href="assets/icon.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -34,268 +34,308 @@
     </div>
   </nav>
 
+  <!-- ════════ HERO ════════ -->
   <section class="hero">
     <div class="container">
       <div class="hero-waveform fade-up" aria-hidden="true">
-        <span class="wave-bar"></span>
-        <span class="wave-bar"></span>
-        <span class="wave-bar"></span>
-        <span class="wave-bar"></span>
-        <span class="wave-bar"></span>
-        <span class="wave-bar"></span>
-        <span class="wave-bar"></span>
-        <span class="wave-bar"></span>
-        <span class="wave-bar"></span>
-        <span class="wave-bar"></span>
-        <span class="wave-bar"></span>
-        <span class="wave-bar"></span>
+        <span class="wave-bar"></span><span class="wave-bar"></span><span class="wave-bar"></span><span class="wave-bar"></span><span class="wave-bar"></span>
+        <span class="wave-bar"></span><span class="wave-bar"></span><span class="wave-bar"></span><span class="wave-bar"></span><span class="wave-bar"></span>
       </div>
       <h1 class="hero-title fade-up" data-delay="1">
-        Record meetings locally.<br>Set up in minutes.<br>No bots in your calls.
+        Record meetings locally.<br>No bots. No cloud.
       </h1>
       <p class="hero-subtitle fade-up" data-delay="2">
-        Frajola guides first-time setup, checks macOS permissions in real time,
-        downloads your first Whisper model, and can help with Ollama setup.
+        Whisper transcription and AI summaries run entirely on your machine.
+        Minimize the app and keep recording from a floating overlay.
       </p>
       <div class="hero-actions fade-up" data-delay="3">
         <a href="#download" class="btn btn-primary btn-lg">Download for free</a>
         <a href="docs/" class="btn btn-ghost btn-lg">Read the docs</a>
       </div>
-      <p class="hero-platforms fade-up" data-delay="4">
-        Currently tuned for macOS 14.2+ with cross-platform targets in progress.
-      </p>
+      <p class="hero-platforms fade-up" data-delay="4">macOS, Windows, and Linux.</p>
+
+      <!-- ── Interactive App Showcase ── -->
+      <div class="hero-showcase fade-up" data-delay="5">
+        <div class="sc-glow" aria-hidden="true"></div>
+
+        <div class="sc-app">
+          <!-- macOS title bar -->
+          <div class="sc-titlebar">
+            <div class="sc-dots">
+              <span class="sc-dot sc-dot--close"></span>
+              <span class="sc-dot sc-dot--min"></span>
+              <span class="sc-dot sc-dot--max"></span>
+            </div>
+          </div>
+
+          <div class="sc-body">
+            <!-- Icon Rail -->
+            <div class="sc-rail">
+              <div class="sc-rail-top">
+                <img src="assets/icon.png" class="sc-rail-logo" alt="" width="32" height="32">
+                <button class="sc-rail-btn sc-rail-btn--active" aria-label="Home">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+                </button>
+              </div>
+              <div class="sc-rail-bottom">
+                <div class="sc-rail-record"><span class="sc-rail-record-dot"></span></div>
+                <button class="sc-rail-btn" aria-label="Settings">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
+                </button>
+              </div>
+            </div>
+
+            <!-- Sidebar -->
+            <div class="sc-sidebar">
+              <div class="sc-sidebar-header">Meetings</div>
+              <div class="sc-sidebar-scroll">
+                <div class="sc-group-label">TODAY</div>
+                <div class="sc-meeting sc-meeting--active">
+                  <div class="sc-meeting-title">Sprint Planning</div>
+                  <div class="sc-meeting-sub">Engineering Team</div>
+                  <div class="sc-meeting-dur">45m</div>
+                </div>
+                <div class="sc-meeting">
+                  <div class="sc-meeting-title">1:1 with Sarah</div>
+                  <div class="sc-meeting-sub">Manager Sync</div>
+                  <div class="sc-meeting-dur">30m</div>
+                </div>
+
+                <div class="sc-group-label">YESTERDAY</div>
+                <div class="sc-meeting">
+                  <div class="sc-meeting-title">Product Review</div>
+                  <div class="sc-meeting-sub">Design + Product</div>
+                  <div class="sc-meeting-dur">1h 0m</div>
+                </div>
+                <div class="sc-meeting">
+                  <div class="sc-meeting-title">Client Onboarding Call</div>
+                  <div class="sc-meeting-sub">Acme Corp</div>
+                  <div class="sc-meeting-dur">40m</div>
+                </div>
+
+                <div class="sc-group-label">PREVIOUS 7 DAYS</div>
+                <div class="sc-meeting">
+                  <div class="sc-meeting-title">Architecture Discussion</div>
+                  <div class="sc-meeting-sub">Backend Team</div>
+                  <div class="sc-meeting-dur">1h 15m</div>
+                </div>
+                <div class="sc-meeting">
+                  <div class="sc-meeting-title">Reuniao de Alinhamento</div>
+                  <div class="sc-meeting-sub">Time Brasil</div>
+                  <div class="sc-meeting-dur">25m</div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Main Panel -->
+            <div class="sc-main">
+              <h2 class="sc-detail-title">Sprint Planning</h2>
+              <p class="sc-detail-sub">Engineering Team</p>
+              <div class="sc-detail-meta">
+                <span>
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+                  Created: <strong>Mar 4, 2026 at 10:00 AM</strong>
+                </span>
+                <span>
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+                  Duration: <strong>45m</strong>
+                </span>
+                <span>
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
+                  Status: <strong>Complete</strong>
+                </span>
+              </div>
+
+              <!-- Tabs -->
+              <div class="sc-tabs">
+                <button class="sc-tab sc-tab--active" data-tab="summary">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8Z"/><path d="M14 2v6h6"/><path d="M16 13H8"/><path d="M16 17H8"/></svg>
+                  Summary
+                </button>
+                <button class="sc-tab" data-tab="actions">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/></svg>
+                  Action Items
+                </button>
+                <button class="sc-tab" data-tab="transcript">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+                  Transcript
+                </button>
+              </div>
+
+              <!-- Summary -->
+              <div class="sc-panel" id="sc-summary">
+                <div class="sc-section-label">OVERVIEW</div>
+                <p class="sc-overview">The engineering team reviewed the backlog and committed to 34 story points for the upcoming sprint. Key focus areas include the new auth flow, performance improvements to the dashboard, and finishing the export feature.</p>
+
+                <div class="sc-section-label">KEY POINTS</div>
+                <ul class="sc-key-points">
+                  <li>Auth flow migration to OAuth2 starts this sprint</li>
+                  <li>Dashboard load time target: under 2 seconds</li>
+                  <li>Export feature needs QA before release</li>
+                  <li>Two new hires joining next Monday</li>
+                </ul>
+
+                <div class="sc-section-label">DECISIONS</div>
+                <ul class="sc-decisions">
+                  <li>Use Postgres for the new analytics service instead of ClickHouse</li>
+                  <li>Postpone mobile app work to next quarter</li>
+                </ul>
+              </div>
+
+              <!-- Action Items -->
+              <div class="sc-panel" id="sc-actions" hidden>
+                <div class="sc-action-item"><div class="sc-action-checkbox"></div><div class="sc-action-text">Start OAuth2 migration — create branch and initial PR</div><div class="sc-action-assignee">Sarah</div></div>
+                <div class="sc-action-item"><div class="sc-action-checkbox"></div><div class="sc-action-text">Implement lazy loading for dashboard charts</div><div class="sc-action-assignee">Jordan</div></div>
+                <div class="sc-action-item"><div class="sc-action-checkbox"></div><div class="sc-action-text">QA the export feature by Wednesday</div><div class="sc-action-assignee">Mark</div></div>
+                <div class="sc-action-item"><div class="sc-action-checkbox"></div><div class="sc-action-text">Prepare onboarding docs for new hires</div><div class="sc-action-assignee">Alex</div></div>
+              </div>
+
+              <!-- Transcript -->
+              <div class="sc-panel" id="sc-transcript" hidden>
+                <div class="sc-transcript-line"><span class="sc-ts">00:00:12</span><span class="sc-speaker">Alex</span><span class="sc-text">Alright, let's get started with sprint planning. We've got a few things to cover today.</span></div>
+                <div class="sc-transcript-line"><span class="sc-ts">00:00:28</span><span class="sc-speaker">Sarah</span><span class="sc-text">I've prioritized the backlog. The auth migration is the biggest item — about 13 points.</span></div>
+                <div class="sc-transcript-line"><span class="sc-ts">00:01:15</span><span class="sc-speaker">Alex</span><span class="sc-text">That makes sense. We've been putting it off. What about the dashboard performance work?</span></div>
+                <div class="sc-transcript-line"><span class="sc-ts">00:01:42</span><span class="sc-speaker">Jordan</span><span class="sc-text">I've been profiling it. Main bottleneck is the chart rendering — I can get it under 2 seconds with lazy loading.</span></div>
+                <div class="sc-transcript-line"><span class="sc-ts">00:02:30</span><span class="sc-speaker">Sarah</span><span class="sc-text">Perfect. And the export feature just needs QA at this point. Mark, can you pick that up?</span></div>
+                <div class="sc-transcript-line"><span class="sc-ts">00:02:48</span><span class="sc-speaker">Mark</span><span class="sc-text">Yeah, I'll have it tested by Wednesday.</span></div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Overlay Pill -->
+        <div class="sc-pill-wrap">
+          <div class="sc-pill">
+            <img src="assets/icon.png" class="sc-pill-logo" alt="" width="28" height="28">
+            <div class="sc-pill-icon">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/></svg>
+            </div>
+            <div class="sc-pill-rec"><span class="sc-pill-rec-inner"></span></div>
+          </div>
+          <span class="sc-pill-tag">Overlay pill</span>
+        </div>
+      </div>
     </div>
   </section>
 
+  <!-- ════════ HOW IT WORKS ════════ -->
   <section class="section" id="how-it-works">
     <div class="container">
       <p class="section-label fade-up">How it works</p>
-      <p class="section-headline fade-up">Guided setup, then one-click recording.</p>
-      <p class="section-subtitle fade-up">No account creation. No external meeting bot.</p>
-      <div class="steps-grid">
-        <div class="step-card fade-up" data-delay="1">
-          <div class="step-icon">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" y1="19" x2="12" y2="22"/></svg>
-          </div>
+      <p class="section-headline fade-up">Three steps, nothing in the cloud.</p>
+      <p class="section-subtitle fade-up">No account creation. No external meeting bots.</p>
+      <div class="steps-grid fade-up" data-delay="1">
+        <div class="step-card">
           <div class="step-number">01</div>
           <h3>Run onboarding</h3>
-          <p>Choose setup mode, grant permissions, and pick your first Whisper and AI models.</p>
+          <p>Grant permissions, pick your Whisper model, and optionally set up Ollama for local AI summaries.</p>
         </div>
-        <div class="step-card fade-up" data-delay="2">
-          <div class="step-icon">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
-          </div>
+        <div class="step-card">
           <div class="step-number">02</div>
           <h3>Record from app or overlay</h3>
-          <p>Control recording from the main window or the floating overlay when the app is minimized.</p>
+          <p>Start recording in the main window. Minimize it and the floating overlay keeps you in control.</p>
         </div>
-        <div class="step-card fade-up" data-delay="3">
-          <div class="step-icon">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8Z"/><path d="M14 2v6h6"/><path d="M16 13H8"/><path d="M16 17H8"/><path d="M10 9H8"/></svg>
-          </div>
+        <div class="step-card">
           <div class="step-number">03</div>
           <h3>Get transcript and notes</h3>
-          <p>Whisper transcribes locally; AI summaries can run via Ollama or optional cloud providers.</p>
+          <p>Whisper transcribes locally. AI generates a summary with key points, decisions, and action items.</p>
         </div>
       </div>
     </div>
   </section>
 
+  <!-- ════════ FEATURES ════════ -->
   <section class="section" id="features">
     <div class="container">
-      <p class="section-label fade-up">Shipped Features</p>
+      <p class="section-label fade-up">Features</p>
       <p class="section-headline fade-up">Built and available today.</p>
-      <p class="section-subtitle fade-up">These are implemented in the desktop app right now.</p>
+      <p class="section-subtitle fade-up">Everything ships in the desktop app. No plugins, no extensions.</p>
       <div class="features-grid">
-        <div class="feature-card fade-up" data-delay="1">
-          <div class="feature-icon">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v20"/><path d="M2 12h20"/></svg>
-          </div>
-          <h3>First-run onboarding</h3>
-          <p>Guided setup with mode selection, permission checks, model download, and skip-AI option.</p>
-        </div>
-        <div class="feature-card fade-up" data-delay="2">
-          <div class="feature-icon">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
-          </div>
-          <h3>Local audio capture</h3>
-          <p>Captures microphone and system audio together, with pause/resume and local WAV storage.</p>
-        </div>
-        <div class="feature-card fade-up" data-delay="3">
-          <div class="feature-icon">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-          </div>
-          <h3>Whisper model manager</h3>
-          <p>Download and switch `tiny`, `base`, `small`, and `medium` directly from onboarding or settings.</p>
-        </div>
-        <div class="feature-card fade-up" data-delay="1">
-          <div class="feature-icon">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 12h8"/><path d="M12 8v8"/></svg>
-          </div>
-          <h3>AI provider flexibility</h3>
-          <p>Use local Ollama models or switch summaries to OpenAI/Anthropic with your own API keys.</p>
-        </div>
-        <div class="feature-card fade-up" data-delay="2">
-          <div class="feature-icon">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
-          </div>
-          <h3>Overlay-only workflow</h3>
-          <p>Minimize or hide the main app and keep recording controls in a compact floating overlay.</p>
-        </div>
-        <div class="feature-card fade-up" data-delay="3">
-          <div class="feature-icon">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-9-9"/><polyline points="21 3 21 9 15 9"/></svg>
-          </div>
-          <h3>Re-transcribe anytime</h3>
-          <p>Re-run transcription + summarization from the stored audio using a different model or provider.</p>
-        </div>
+        <div class="feature-card fade-up" data-delay="1"><div class="feature-number">01</div><h3>Guided onboarding</h3><p>First-run setup walks you through permissions, model downloads, and AI configuration. Choose full local, transcript-only, or cloud summaries.</p></div>
+        <div class="feature-card fade-up" data-delay="2"><div class="feature-number">02</div><h3>Local audio capture</h3><p>Captures microphone and system audio together as a single WAV file. Pause, resume, and stop from the app or the overlay.</p></div>
+        <div class="feature-card fade-up" data-delay="1"><div class="feature-number">03</div><h3>Whisper model manager</h3><p>Download and switch between tiny, base, small, and medium Whisper models directly from settings.</p></div>
+        <div class="feature-card fade-up" data-delay="2"><div class="feature-number">04</div><h3>AI provider flexibility</h3><p>Use local Ollama models for fully private summaries, or switch to OpenAI and Anthropic with your own API keys.</p></div>
+        <div class="feature-card fade-up" data-delay="1"><div class="feature-number">05</div><h3>Floating overlay</h3><p>Minimize the app and a compact floating pill stays on screen with recording controls, duration, and waveform.</p></div>
+        <div class="feature-card fade-up" data-delay="2"><div class="feature-number">06</div><h3>Re-transcribe anytime</h3><p>Re-run transcription and summarization from the stored audio using a different model or provider.</p></div>
       </div>
     </div>
   </section>
 
+  <!-- ════════ PROCESSING OPTIONS ════════ -->
   <section class="section" id="privacy">
     <div class="container">
-      <p class="section-label fade-up">Processing Options</p>
-      <p class="section-headline fade-up">Local by default, cloud only when you choose it.</p>
-      <p class="section-subtitle fade-up">Today, cloud usage applies to AI summaries only. Transcription is local Whisper.</p>
+      <p class="section-label fade-up">Processing</p>
+      <p class="section-headline fade-up">Local by default.</p>
+      <p class="section-subtitle fade-up">Transcription is always local Whisper. Cloud usage only applies to AI summaries, and only when you enable it.</p>
       <div class="privacy-cards">
         <div class="privacy-card privacy-card--active fade-up" data-delay="1">
           <div class="privacy-badge">Default</div>
           <h3>Local Summaries</h3>
           <dl>
-            <div>
-              <dt>Transcription</dt>
-              <dd>Local Whisper</dd>
-            </div>
-            <div>
-              <dt>AI Notes</dt>
-              <dd>Ollama local model</dd>
-            </div>
-            <div>
-              <dt>Data leaving device</dt>
-              <dd class="highlight-green">None</dd>
-            </div>
+            <div><dt>Transcription</dt><dd>Local Whisper</dd></div>
+            <div><dt>AI Notes</dt><dd>Ollama local model</dd></div>
+            <div><dt>Data leaving device</dt><dd class="highlight-green">None</dd></div>
           </dl>
         </div>
         <div class="privacy-card fade-up" data-delay="2">
-          <h3>Transcription Only</h3>
+          <h3>Transcript Only</h3>
           <dl>
-            <div>
-              <dt>Transcription</dt>
-              <dd>Local Whisper</dd>
-            </div>
-            <div>
-              <dt>AI Notes</dt>
-              <dd>Disabled</dd>
-            </div>
-            <div>
-              <dt>Data leaving device</dt>
-              <dd class="highlight-green">None</dd>
-            </div>
+            <div><dt>Transcription</dt><dd>Local Whisper</dd></div>
+            <div><dt>AI Notes</dt><dd>Disabled</dd></div>
+            <div><dt>Data leaving device</dt><dd class="highlight-green">None</dd></div>
           </dl>
         </div>
         <div class="privacy-card fade-up" data-delay="3">
           <h3>Cloud Summaries</h3>
           <dl>
-            <div>
-              <dt>Transcription</dt>
-              <dd>Local Whisper</dd>
-            </div>
-            <div>
-              <dt>AI Notes</dt>
-              <dd>OpenAI or Anthropic</dd>
-            </div>
-            <div>
-              <dt>Data leaving device</dt>
-              <dd class="highlight-yellow">Transcript text only</dd>
-            </div>
+            <div><dt>Transcription</dt><dd>Local Whisper</dd></div>
+            <div><dt>AI Notes</dt><dd>OpenAI or Anthropic</dd></div>
+            <div><dt>Data leaving device</dt><dd class="highlight-yellow">Transcript text only</dd></div>
           </dl>
         </div>
       </div>
     </div>
   </section>
 
-  <section class="section" id="roadmap">
-    <div class="container">
-      <p class="section-label fade-up">Roadmap</p>
-      <p class="section-headline fade-up">Search, export, i18n, and git workflows are next.</p>
-      <p class="section-subtitle fade-up">See the PRD-backed feature board with shipped vs pending items.</p>
-      <div class="hero-actions fade-up">
-        <a href="next-features.html" class="btn btn-primary btn-md">Open Next Features</a>
-        <a href="docs/" class="btn btn-ghost btn-md">Open Docs</a>
-      </div>
-    </div>
-  </section>
-
+  <!-- ════════ DOWNLOAD ════════ -->
   <section class="section section--cta" id="download">
     <div class="container">
       <p class="section-headline fade-up">Try Frajola.</p>
-      <p class="section-subtitle fade-up">Download the latest desktop build from GitHub Releases.</p>
+      <p class="section-subtitle fade-up">Free and open source. Download from GitHub Releases.</p>
       <div class="download-grid">
-        <a
-          href="https://github.com/victorlucss/frajola/releases/latest"
-          class="download-card fade-up"
-          data-delay="1"
-          data-release-platform="macos-arm"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <a href="https://github.com/victorlucss/frajola/releases/latest" class="download-card fade-up" data-delay="1" data-release-platform="macos-arm" target="_blank" rel="noopener noreferrer">
           <svg viewBox="0 0 24 24" fill="currentColor"><path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/></svg>
           <span class="download-platform">macOS (Apple Silicon)</span>
-          <span class="download-ext">.dmg (arm64)</span>
+          <span class="download-ext">.dmg arm64</span>
         </a>
-        <a
-          href="https://github.com/victorlucss/frajola/releases/latest"
-          class="download-card fade-up"
-          data-delay="2"
-          data-release-platform="macos-intel"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <a href="https://github.com/victorlucss/frajola/releases/latest" class="download-card fade-up" data-delay="2" data-release-platform="macos-intel" target="_blank" rel="noopener noreferrer">
           <svg viewBox="0 0 24 24" fill="currentColor"><path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/></svg>
           <span class="download-platform">macOS (Intel)</span>
-          <span class="download-ext">.dmg (x64)</span>
+          <span class="download-ext">.dmg x64</span>
         </a>
-        <a
-          href="https://github.com/victorlucss/frajola/releases/latest"
-          class="download-card fade-up"
-          data-delay="3"
-          data-release-platform="windows"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <a href="https://github.com/victorlucss/frajola/releases/latest" class="download-card fade-up" data-delay="3" data-release-platform="windows" target="_blank" rel="noopener noreferrer">
           <svg viewBox="0 0 24 24" fill="currentColor"><path d="M0 3.449L9.75 2.1v9.451H0m10.949-9.602L24 0v11.4H10.949M0 12.6h9.75v9.451L0 20.699M10.949 12.6H24V24l-12.9-1.801"/></svg>
           <span class="download-platform">Windows</span>
           <span class="download-ext">.msi</span>
         </a>
-        <a
-          href="https://github.com/victorlucss/frajola/releases/latest"
-          class="download-card fade-up"
-          data-delay="4"
-          data-release-platform="linux"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <a href="https://github.com/victorlucss/frajola/releases/latest" class="download-card fade-up" data-delay="4" data-release-platform="linux" target="_blank" rel="noopener noreferrer">
           <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12.504 0c-.155 0-.311.015-.466.045C9.173.723 8.12 3.576 9.241 6.13c.196.434.49.922.743 1.283-1.298.19-2.85.736-4.277 1.556-2.574 1.478-3.863 3.307-3.874 3.324A4.32 4.32 0 0 0 1 14.583c0 2.456 2.212 4.327 5.178 4.327 1.065 0 2.08-.247 2.97-.63.108.345.234.682.397.998.553 1.076 1.362 1.884 2.455 2.422 1.09.54 2.348.745 3.684.412 1.02-.255 1.81-.782 2.38-1.451.43-.504.704-1.091.9-1.665 1.823.155 3.58-.385 4.887-1.556 1.438-1.286 2.15-3.12 2.15-4.857 0-2.226-1.252-4.33-3.243-5.515-.218-.13-.448-.245-.683-.35.078-.522.078-1.066-.017-1.63C21.66 2.858 19.707.607 17.131.091A5.402 5.402 0 0 0 15.818 0c-1.146 0-2.18.455-3.008 1.182A4.42 4.42 0 0 0 12.504 0z"/></svg>
           <span class="download-platform">Linux</span>
           <span class="download-ext">.AppImage</span>
         </a>
       </div>
-      <p class="download-note fade-up" id="download-note">
-        Resolving latest release assets...
-      </p>
+      <p class="download-note fade-up" id="download-note">Resolving latest release assets...</p>
+      <div class="roadmap-cta fade-up"><a href="next-features.html" class="btn btn-ghost btn-md">View Roadmap</a></div>
     </div>
   </section>
 
   <footer class="footer">
     <div class="container footer-inner">
-      <div class="footer-brand">
-        <img src="assets/icon.png" alt="" width="24" height="24">
-        <span>Frajola</span>
-      </div>
+      <div class="footer-brand"><img src="assets/icon.png" alt="" width="24" height="24"><span>Frajola</span></div>
       <nav class="footer-links">
         <a href="docs/">Docs</a>
-        <a href="next-features.html">Next Features</a>
+        <a href="next-features.html">Roadmap</a>
+        <a href="https://github.com/victorlucss/frajola" target="_blank" rel="noopener noreferrer">GitHub</a>
       </nav>
       <p class="footer-copy">Made in Brazil.</p>
     </div>
@@ -304,5 +344,26 @@
   <script defer src="js/animations.js"></script>
   <script defer src="js/nav.js"></script>
   <script defer src="js/release-links.js"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      // Tab switching
+      document.querySelectorAll('.sc-tab').forEach(tab => {
+        tab.addEventListener('click', () => {
+          document.querySelectorAll('.sc-tab').forEach(t => t.classList.remove('sc-tab--active'));
+          document.querySelectorAll('.sc-panel').forEach(p => p.hidden = true);
+          tab.classList.add('sc-tab--active');
+          const panel = document.getElementById('sc-' + tab.dataset.tab);
+          if (panel) panel.hidden = false;
+        });
+      });
+      // Meeting selection (visual only)
+      document.querySelectorAll('.sc-meeting').forEach(item => {
+        item.addEventListener('click', () => {
+          document.querySelectorAll('.sc-meeting').forEach(m => m.classList.remove('sc-meeting--active'));
+          item.classList.add('sc-meeting--active');
+        });
+      });
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## What

Replace the static app screenshot on the landing page with a fully interactive HTML/CSS recreation of the Frajola desktop app UI. Visitors can now click tabs (Summary, Action Items, Transcript) and select meetings in the sidebar — all rendered as lightweight markup with no images or JavaScript frameworks.

Also includes a visual refresh of the entire landing page: warmer color palette, new display/body fonts (Bricolage Grotesque + Outfit), film grain texture, pill-shaped buttons, and restructured section layouts.

## Why

A static screenshot cannot be updated easily as the app evolves, and it adds a large image payload to the page. An interactive HTML/CSS showcase:
- Lets visitors **experience** the app UI directly on the landing page
- Stays in sync with design changes through CSS tokens
- Eliminates the ~284 KB screenshot download
- Demonstrates the product's polish before downloading

## How

**Design tokens** (`css/tokens.css`)
- Shifted all backgrounds and text to warm charcoal/cream tones
- Added `--font-display` (Bricolage Grotesque) and `--font-body` (Outfit)
- New tokens: `--accent-glow-strong`, `--weight-extrabold`, `--tracking-wider`, `--shadow-xl`, `--ease-spring`, `--z-grain`

**Base styles** (`css/base.css`)
- Replaced Inter font import with Bricolage Grotesque + Outfit
- Added slim custom scrollbars for showcase panels
- Added film grain pseudo-element overlay on `body::after`
- Heading elements now default to display font
- Buttons are now pill-shaped (`border-radius: full`)
- Nav and footer styling refined

**Animations** (`css/animations.css`)
- Waveform reduced from 12 to 10 bars with adjusted heights
- New `float` keyframes for overlay pill hover animation
- New `glow-breathe` for showcase backdrop pulse
- New `rec-pulse` for record button indicator
- Spring easing (`cubic-bezier(0.16, 1, 0.3, 1)`) on fade-up reveals
- All new animations respect `prefers-reduced-motion`

**Landing CSS** (`css/landing.css`)
- Full `.sc-*` component system: titlebar, icon rail, sidebar, main panel, tabs, transcript grid, action items, overlay pill
- Steps grid restructured as a single bordered row with large step numbers
- Features grid changed from 3-column to 2-column with numbered cards
- Mobile breakpoints collapse showcase to single-column (sidebar hidden)

**HTML** (`index.html`)
- Hero section now contains the interactive showcase with macOS window chrome, icon rail, sidebar with grouped meeting list (Today / Yesterday / Previous 7 Days), and main panel with three tab panels
- Floating overlay pill positioned below the app frame with float animation
- Inline JS (~20 lines) handles tab switching and meeting selection
- Updated hero copy, section headings, and footer links
- Roadmap link moved into download section

## Checklist

- [x] No build step required (static HTML/CSS site)
- [x] All animations respect `prefers-reduced-motion: reduce`
- [x] Mobile responsive (sidebar collapses, showcase adapts)
- [x] No external dependencies added (fonts already loaded via Google Fonts)
- [x] No images required for the showcase (pure HTML/CSS)