### PR TITLE
fix: detect silent audio and prevent blank transcripts

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "frajola"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cpal",
  "futures-util",
@@ -1080,6 +1080,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-log",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "whisper-rs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,3 +31,6 @@ rubato = "0.16"
 reqwest = { version = "0.12", features = ["stream", "json"] }
 futures-util = "0.3"
 tokio = { version = "1", features = ["rt", "sync"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -14,6 +14,8 @@ pub struct CaptureHandles {
     pub writer_thread: JoinHandle<Result<(), String>>,
     /// If system audio capture failed, contains the reason.
     pub system_audio_error: Option<String>,
+    /// Set to `true` if the mic appears silent after the first few seconds of recording.
+    pub silence_warning: Arc<AtomicBool>,
 }
 
 /// Tagged audio chunk so the writer can distinguish sources.
@@ -129,6 +131,9 @@ pub fn start_capture(
     // --- Writer thread ---
     let writer_stop = stop_flag.clone();
     let writer_paused = paused_flag.clone();
+    let silence_flag = Arc::new(AtomicBool::new(false));
+    let writer_silence = silence_flag.clone();
+    let writer_sample_rate = sample_rate;
     let writer_thread = thread::spawn(move || {
         writer_loop(
             rx,
@@ -137,6 +142,8 @@ pub fn start_capture(
             writer_paused,
             has_system_audio,
             sys_resample_ratio,
+            writer_silence,
+            writer_sample_rate,
         )
     });
 
@@ -145,6 +152,7 @@ pub fn start_capture(
         system_stream,
         writer_thread,
         system_audio_error,
+        silence_warning: silence_flag,
     })
 }
 
@@ -254,9 +262,17 @@ fn writer_loop(
     paused_flag: Arc<AtomicBool>,
     has_system_audio: bool,
     sys_resample_ratio: Option<f64>,
+    silence_flag: Arc<AtomicBool>,
+    sample_rate: u32,
 ) -> Result<(), String> {
     let mut mic_buf: Vec<f32> = Vec::new();
     let mut sys_buf: Vec<f32> = Vec::new();
+
+    // Silence detection: accumulate mic energy for the first 3 seconds
+    let mut mic_samples_counted: u64 = 0;
+    let mut mic_sum_sq: f64 = 0.0;
+    let silence_check_samples = (sample_rate as u64) * 3;
+    let mut silence_checked = false;
 
     loop {
         match rx.recv_timeout(std::time::Duration::from_millis(100)) {
@@ -266,7 +282,26 @@ fn writer_loop(
                 }
 
                 match chunk {
-                    AudioChunk::Mic(samples) => mic_buf.extend_from_slice(&samples),
+                    AudioChunk::Mic(samples) => {
+                        if !silence_checked {
+                            for &s in &samples {
+                                mic_sum_sq += (s as f64) * (s as f64);
+                            }
+                            mic_samples_counted += samples.len() as u64;
+                            if mic_samples_counted >= silence_check_samples {
+                                let rms =
+                                    (mic_sum_sq / mic_samples_counted as f64).sqrt();
+                                if rms < 1e-4 {
+                                    silence_flag.store(true, Ordering::Relaxed);
+                                    log::warn!(
+                                        "Mic audio appears silent after 3s (RMS={rms:.6})"
+                                    );
+                                }
+                                silence_checked = true;
+                            }
+                        }
+                        mic_buf.extend_from_slice(&samples);
+                    }
                     AudioChunk::System(samples) => {
                         let resampled = match sys_resample_ratio {
                             Some(ratio) => resample_linear(&samples, ratio),
@@ -386,4 +421,245 @@ fn flush_remaining(
     mic_buf.clear();
     sys_buf.clear();
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- Linear resampling tests ---
+
+    #[test]
+    fn resample_linear_empty_input() {
+        assert!(resample_linear(&[], 0.5).is_empty());
+    }
+
+    #[test]
+    fn resample_linear_same_rate() {
+        let input = vec![1.0, 2.0, 3.0, 4.0];
+        let output = resample_linear(&input, 1.0);
+        assert_eq!(output.len(), input.len());
+        for (a, b) in input.iter().zip(&output) {
+            assert!((a - b).abs() < 1e-6);
+        }
+    }
+
+    #[test]
+    fn resample_linear_downsample_halves() {
+        let input: Vec<f32> = (0..100).map(|i| i as f32).collect();
+        let output = resample_linear(&input, 0.5);
+        assert_eq!(output.len(), 50);
+        // First sample should be close to 0.0
+        assert!(output[0].abs() < 1e-6);
+    }
+
+    #[test]
+    fn resample_linear_upsample_doubles() {
+        let input = vec![0.0, 1.0, 0.0];
+        let output = resample_linear(&input, 2.0);
+        assert_eq!(output.len(), 6);
+        // Should interpolate smoothly
+        assert!(output[0].abs() < 1e-6); // 0.0
+        assert!(output[2] > 0.4); // near 1.0
+    }
+
+    #[test]
+    fn resample_linear_preserves_silence() {
+        let input = vec![0.0f32; 1000];
+        let output = resample_linear(&input, 0.333);
+        for s in &output {
+            assert_eq!(*s, 0.0, "Silence should remain silent after resampling");
+        }
+    }
+
+    // --- Interleave tests ---
+
+    #[test]
+    fn interleave_stereo_basic() {
+        let left = vec![1.0, 3.0, 5.0];
+        let right = vec![2.0, 4.0, 6.0];
+        let stereo = interleave_stereo(&left, &right);
+        assert_eq!(stereo, vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    }
+
+    #[test]
+    fn interleave_stereo_unequal_lengths() {
+        let left = vec![1.0, 3.0, 5.0];
+        let right = vec![2.0, 4.0];
+        let stereo = interleave_stereo(&left, &right);
+        // Should only interleave min(3,2)=2 frames
+        assert_eq!(stereo, vec![1.0, 2.0, 3.0, 4.0]);
+    }
+
+    // --- Silence detection integration test ---
+
+    #[test]
+    fn writer_loop_detects_silence() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("silence_test.wav");
+        let encoder = WavEncoder::new(&path, 48000, 1).unwrap();
+
+        let (tx, rx) = mpsc::channel::<AudioChunk>();
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        let paused_flag = Arc::new(AtomicBool::new(false));
+        let silence_flag = Arc::new(AtomicBool::new(false));
+        let silence_clone = silence_flag.clone();
+        let stop_clone = stop_flag.clone();
+
+        let handle = thread::spawn(move || {
+            writer_loop(
+                rx, encoder, stop_clone, paused_flag, false, None,
+                silence_clone, 48000,
+            )
+        });
+
+        // Send 4 seconds of silent mic audio in chunks
+        for _ in 0..400 {
+            tx.send(AudioChunk::Mic(vec![0.0f32; 480])).unwrap();
+        }
+
+        // Give the writer thread a moment to process
+        std::thread::sleep(std::time::Duration::from_millis(100));
+
+        // Stop and join
+        stop_flag.store(true, Ordering::Relaxed);
+        drop(tx);
+        handle.join().unwrap().unwrap();
+
+        assert!(silence_flag.load(Ordering::Relaxed),
+            "Silence flag should be set for silent audio");
+    }
+
+    #[test]
+    fn writer_loop_no_silence_for_tone() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tone_test.wav");
+        let encoder = WavEncoder::new(&path, 48000, 1).unwrap();
+
+        let (tx, rx) = mpsc::channel::<AudioChunk>();
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        let paused_flag = Arc::new(AtomicBool::new(false));
+        let silence_flag = Arc::new(AtomicBool::new(false));
+        let silence_clone = silence_flag.clone();
+        let stop_clone = stop_flag.clone();
+
+        let handle = thread::spawn(move || {
+            writer_loop(
+                rx, encoder, stop_clone, paused_flag, false, None,
+                silence_clone, 48000,
+            )
+        });
+
+        // Send 4 seconds of 440Hz tone in chunks
+        let freq = 440.0f32;
+        let sample_rate = 48000.0f32;
+        for chunk_idx in 0..400 {
+            let chunk: Vec<f32> = (0..480)
+                .map(|i| {
+                    let t = (chunk_idx * 480 + i) as f32 / sample_rate;
+                    (2.0 * std::f32::consts::PI * freq * t).sin() * 0.5
+                })
+                .collect();
+            tx.send(AudioChunk::Mic(chunk)).unwrap();
+        }
+
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        stop_flag.store(true, Ordering::Relaxed);
+        drop(tx);
+        handle.join().unwrap().unwrap();
+
+        assert!(!silence_flag.load(Ordering::Relaxed),
+            "Silence flag should NOT be set for audio with tone");
+    }
+
+    // --- Full round-trip: write WAV → read → check RMS ---
+
+    #[test]
+    fn roundtrip_silent_wav_detected_by_rms_check() {
+        use crate::transcribe::resample::load_and_resample_with_energy;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("roundtrip_silent.wav");
+
+        // Simulate a recording that produces silence (e.g., no mic permission)
+        let encoder = WavEncoder::new(&path, 48000, 1).unwrap();
+        let (tx, rx) = mpsc::channel::<AudioChunk>();
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        let paused_flag = Arc::new(AtomicBool::new(false));
+        let silence_flag = Arc::new(AtomicBool::new(false));
+        let stop_clone = stop_flag.clone();
+
+        let handle = thread::spawn(move || {
+            writer_loop(
+                rx, encoder, stop_clone, paused_flag, false, None,
+                silence_flag, 48000,
+            )
+        });
+
+        // Send 1 second of silence
+        for _ in 0..100 {
+            tx.send(AudioChunk::Mic(vec![0.0f32; 480])).unwrap();
+        }
+        stop_flag.store(true, Ordering::Relaxed);
+        drop(tx);
+        handle.join().unwrap().unwrap();
+
+        // Now load the WAV through the transcription pipeline
+        let (samples, _) = load_and_resample_with_energy(&path).unwrap();
+
+        let audio_rms = {
+            let sum_sq: f64 = samples.iter().map(|&s| (s as f64) * (s as f64)).sum();
+            (sum_sq / samples.len().max(1) as f64).sqrt()
+        };
+
+        assert!(audio_rms < 1e-4,
+            "Silent recording should be caught by RMS check (got {audio_rms:.6})");
+    }
+
+    #[test]
+    fn roundtrip_tone_wav_passes_rms_check() {
+        use crate::transcribe::resample::load_and_resample_with_energy;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("roundtrip_tone.wav");
+
+        let encoder = WavEncoder::new(&path, 48000, 1).unwrap();
+        let (tx, rx) = mpsc::channel::<AudioChunk>();
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        let paused_flag = Arc::new(AtomicBool::new(false));
+        let silence_flag = Arc::new(AtomicBool::new(false));
+        let stop_clone = stop_flag.clone();
+
+        let handle = thread::spawn(move || {
+            writer_loop(
+                rx, encoder, stop_clone, paused_flag, false, None,
+                silence_flag, 48000,
+            )
+        });
+
+        // Send 1 second of 440Hz tone
+        let freq = 440.0f32;
+        for chunk_idx in 0..100 {
+            let chunk: Vec<f32> = (0..480)
+                .map(|i| {
+                    let t = (chunk_idx * 480 + i) as f32 / 48000.0;
+                    (2.0 * std::f32::consts::PI * freq * t).sin() * 0.5
+                })
+                .collect();
+            tx.send(AudioChunk::Mic(chunk)).unwrap();
+        }
+        stop_flag.store(true, Ordering::Relaxed);
+        drop(tx);
+        handle.join().unwrap().unwrap();
+
+        let (samples, _) = load_and_resample_with_energy(&path).unwrap();
+
+        let audio_rms = {
+            let sum_sq: f64 = samples.iter().map(|&s| (s as f64) * (s as f64)).sum();
+            (sum_sq / samples.len().max(1) as f64).sqrt()
+        };
+
+        assert!(audio_rms > 0.1,
+            "Tone recording should pass RMS check (got {audio_rms:.6})");
+    }
 }

--- a/src-tauri/src/audio/encoder.rs
+++ b/src-tauri/src/audio/encoder.rs
@@ -43,3 +43,73 @@ impl WavEncoder {
 pub fn f32_to_i16(sample: f32) -> i16 {
     (sample.clamp(-1.0, 1.0) * i16::MAX as f32) as i16
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn f32_to_i16_converts_full_range() {
+        assert_eq!(f32_to_i16(1.0), i16::MAX);
+        assert_eq!(f32_to_i16(-1.0), -i16::MAX);
+        assert_eq!(f32_to_i16(0.0), 0);
+    }
+
+    #[test]
+    fn f32_to_i16_clamps_overflow() {
+        assert_eq!(f32_to_i16(2.0), i16::MAX);
+        assert_eq!(f32_to_i16(-2.0), -i16::MAX);
+    }
+
+    #[test]
+    fn f32_to_i16_near_zero_is_silent() {
+        assert_eq!(f32_to_i16(1e-6), 0);
+        assert_eq!(f32_to_i16(-1e-6), 0);
+    }
+
+    #[test]
+    fn wav_encoder_writes_and_reads_back() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.wav");
+
+        let sample_rate = 48000u32;
+        let freq = 440.0f32;
+        let samples: Vec<f32> = (0..sample_rate)
+            .map(|i| (2.0 * std::f32::consts::PI * freq * i as f32 / sample_rate as f32).sin())
+            .collect();
+
+        let mut enc = WavEncoder::new(&path, sample_rate, 1).unwrap();
+        enc.write_f32_samples(&samples).unwrap();
+        enc.finalize().unwrap();
+
+        let reader = hound::WavReader::open(&path).unwrap();
+        let spec = reader.spec();
+        assert_eq!(spec.sample_rate, sample_rate);
+        assert_eq!(spec.channels, 1);
+        assert_eq!(spec.bits_per_sample, 16);
+        assert_eq!(spec.sample_format, SampleFormat::Int);
+
+        let read_samples: Vec<i16> = reader.into_samples::<i16>().map(|s| s.unwrap()).collect();
+        assert_eq!(read_samples.len(), samples.len());
+
+        // Verify audio has meaningful amplitude (not silent)
+        let max_abs = read_samples.iter().map(|s| s.unsigned_abs()).max().unwrap();
+        assert!(max_abs > 10000, "Expected loud audio, got max_abs={max_abs}");
+    }
+
+    #[test]
+    fn wav_encoder_silent_audio_is_zero() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("silent.wav");
+
+        let samples = vec![0.0f32; 48000];
+        let mut enc = WavEncoder::new(&path, 48000, 1).unwrap();
+        enc.write_f32_samples(&samples).unwrap();
+        enc.finalize().unwrap();
+
+        let reader = hound::WavReader::open(&path).unwrap();
+        let read_samples: Vec<i16> = reader.into_samples::<i16>().map(|s| s.unwrap()).collect();
+        let max_abs = read_samples.iter().map(|s| s.unsigned_abs()).max().unwrap();
+        assert_eq!(max_abs, 0, "Silent input should produce zero samples");
+    }
+}

--- a/src-tauri/src/audio/state.rs
+++ b/src-tauri/src/audio/state.rs
@@ -16,6 +16,7 @@ pub struct ActiveRecording {
     pub started_at: Instant,
     pub stop_flag: Arc<AtomicBool>,
     pub paused_flag: Arc<AtomicBool>,
+    pub silence_warning: Arc<AtomicBool>,
     pub writer_thread: Option<JoinHandle<Result<(), String>>>,
     pub _mic_stream: Option<Stream>,
     pub _system_stream: Option<Stream>,

--- a/src-tauri/src/commands/recording.rs
+++ b/src-tauri/src/commands/recording.rs
@@ -105,6 +105,7 @@ pub async fn start_recording(
         started_at: Instant::now(),
         stop_flag,
         paused_flag,
+        silence_warning: handles.silence_warning,
         writer_thread: Some(handles.writer_thread),
         _mic_stream: handles.mic_stream,
         _system_stream: handles.system_stream,
@@ -202,6 +203,20 @@ pub async fn get_recording_status(
 #[tauri::command]
 pub fn list_audio_devices() -> Result<Vec<AudioDevice>, AppError> {
     devices::list_all_devices().map_err(AppError::Audio)
+}
+
+/// Check whether the writer thread has detected silent mic audio.
+#[tauri::command]
+pub async fn check_silence_warning(
+    recording: State<'_, RecordingState>,
+) -> Result<bool, AppError> {
+    let Ok(lock) = recording.active.lock() else {
+        return Ok(false);
+    };
+    Ok(lock
+        .as_ref()
+        .map(|a| a.silence_warning.load(Ordering::Relaxed))
+        .unwrap_or(false))
 }
 
 /// Attempt a short capture to trigger/check macOS microphone + system audio permissions.

--- a/src-tauri/src/commands/transcribe.rs
+++ b/src-tauri/src/commands/transcribe.rs
@@ -81,6 +81,27 @@ pub async fn transcribe_meeting(
         }
     };
 
+    // 5b. Validate audio has meaningful content
+    let audio_rms = {
+        let sum_sq: f64 = samples.iter().map(|&s| (s as f64) * (s as f64)).sum();
+        (sum_sq / samples.len().max(1) as f64).sqrt()
+    };
+    log::info!(
+        "Audio loaded: {} samples ({:.1}s), RMS={:.6}, stereo={}",
+        samples.len(),
+        samples.len() as f64 / 16000.0,
+        audio_rms,
+        energy.is_some()
+    );
+    if audio_rms < 1e-4 {
+        db.update_meeting_status(meeting_id, "failed")?;
+        return Err(AppError::General(
+            "The recording appears to be silent. Check your microphone permissions in \
+             System Settings > Privacy & Security > Microphone."
+                .into(),
+        ));
+    }
+
     // 6. Run Whisper inference (CPU-intensive, run in blocking thread)
     // Let Whisper auto-detect the language from the audio
     let whisper_result = {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -147,6 +147,7 @@ pub fn run() {
             commands::recording::open_audio_permission_settings,
             commands::recording::open_microphone_permission_settings,
             commands::recording::check_audio_permissions,
+            commands::recording::check_silence_warning,
             commands::meetings::get_meeting_detail,
             commands::transcribe::get_whisper_models,
             commands::transcribe::download_model,

--- a/src-tauri/src/transcribe/resample.rs
+++ b/src-tauri/src/transcribe/resample.rs
@@ -127,3 +127,128 @@ fn rms(samples: &[f32]) -> f32 {
     let sum_sq: f32 = samples.iter().map(|s| s * s).sum();
     (sum_sq / samples.len() as f32).sqrt()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audio::encoder::WavEncoder;
+
+    /// Create a test WAV file with a sine tone at the given sample rate and channels.
+    fn write_test_wav(path: &std::path::Path, sample_rate: u32, channels: u16, duration_secs: f32) {
+        let n_samples = (sample_rate as f32 * duration_secs) as usize;
+        let freq = 440.0f32;
+
+        let mut enc = WavEncoder::new(path, sample_rate, channels).unwrap();
+        for i in 0..n_samples {
+            let sample =
+                (2.0 * std::f32::consts::PI * freq * i as f32 / sample_rate as f32).sin() * 0.5;
+            for _ in 0..channels {
+                enc.write_f32_samples(&[sample]).unwrap();
+            }
+        }
+        enc.finalize().unwrap();
+    }
+
+    /// Create a silent WAV file.
+    fn write_silent_wav(path: &std::path::Path, sample_rate: u32, channels: u16, duration_secs: f32) {
+        let n_samples = (sample_rate as f32 * duration_secs) as usize;
+        let samples = vec![0.0f32; n_samples * channels as usize];
+
+        let mut enc = WavEncoder::new(path, sample_rate, channels).unwrap();
+        enc.write_f32_samples(&samples).unwrap();
+        enc.finalize().unwrap();
+    }
+
+    #[test]
+    fn load_mono_wav_returns_none_energy() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mono.wav");
+        write_test_wav(&path, 48000, 1, 0.5);
+
+        let (samples, energy) = load_and_resample_with_energy(&path).unwrap();
+        assert!(energy.is_none(), "Mono WAV should not produce energy frames");
+        // Resampled to 16kHz: 0.5s * 16000 = ~8000 samples
+        assert!(samples.len() > 7000 && samples.len() < 9000,
+            "Expected ~8000 samples, got {}", samples.len());
+    }
+
+    #[test]
+    fn load_stereo_wav_returns_energy_frames() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stereo.wav");
+        write_test_wav(&path, 48000, 2, 0.5);
+
+        let (samples, energy) = load_and_resample_with_energy(&path).unwrap();
+        assert!(energy.is_some(), "Stereo WAV should produce energy frames");
+        let frames = energy.unwrap();
+        // 0.5s at 100ms frames = 5 frames (last partial frame may be dropped)
+        assert!(frames.len() >= 4 && frames.len() <= 5,
+            "Expected 4-5 energy frames, got {}", frames.len());
+        // Each frame should have non-zero energy since we wrote a tone
+        for frame in &frames {
+            assert!(frame.mic_rms > 0.01, "mic_rms too low: {}", frame.mic_rms);
+            assert!(frame.sys_rms > 0.01, "sys_rms too low: {}", frame.sys_rms);
+        }
+        assert!(samples.len() > 7000 && samples.len() < 9000);
+    }
+
+    #[test]
+    fn load_16khz_wav_skips_resampling() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("16k.wav");
+        write_test_wav(&path, 16000, 1, 1.0);
+
+        let (samples, _) = load_and_resample_with_energy(&path).unwrap();
+        // Already at 16kHz, should be exactly 16000 samples
+        assert_eq!(samples.len(), 16000);
+    }
+
+    #[test]
+    fn silent_wav_has_near_zero_rms() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("silent.wav");
+        write_silent_wav(&path, 48000, 1, 1.0);
+
+        let (samples, _) = load_and_resample_with_energy(&path).unwrap();
+
+        let audio_rms = {
+            let sum_sq: f64 = samples.iter().map(|&s| (s as f64) * (s as f64)).sum();
+            (sum_sq / samples.len().max(1) as f64).sqrt()
+        };
+        assert!(audio_rms < 1e-4,
+            "Silent WAV should have RMS < 1e-4, got {audio_rms:.6}");
+    }
+
+    #[test]
+    fn tone_wav_has_meaningful_rms() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tone.wav");
+        write_test_wav(&path, 48000, 1, 1.0);
+
+        let (samples, _) = load_and_resample_with_energy(&path).unwrap();
+
+        let audio_rms = {
+            let sum_sq: f64 = samples.iter().map(|&s| (s as f64) * (s as f64)).sum();
+            (sum_sq / samples.len().max(1) as f64).sqrt()
+        };
+        assert!(audio_rms > 0.1,
+            "Tone WAV should have meaningful RMS, got {audio_rms:.6}");
+    }
+
+    #[test]
+    fn rms_of_empty_is_zero() {
+        assert_eq!(rms(&[]), 0.0);
+    }
+
+    #[test]
+    fn rms_of_silence_is_zero() {
+        assert_eq!(rms(&[0.0; 1000]), 0.0);
+    }
+
+    #[test]
+    fn rms_of_dc_signal() {
+        let samples = vec![0.5f32; 1000];
+        let r = rms(&samples);
+        assert!((r - 0.5).abs() < 1e-6, "RMS of DC 0.5 should be 0.5, got {r}");
+    }
+}

--- a/src-tauri/src/transcribe/whisper.rs
+++ b/src-tauri/src/transcribe/whisper.rs
@@ -71,7 +71,7 @@ pub fn transcribe(
             .map_err(|e| AppError::General(format!("Failed to get segment text: {e}")))?;
 
         // Strip the [SPEAKER_TURN] token that tinydiarize may inject
-        let cleaned = text.replace("[SPEAKER_TURN]", "");
+        let cleaned = text.replace("[SPEAKER_TURN]", "").replace("[BLANK_AUDIO]", "");
         let trimmed = cleaned.trim().to_string();
         if trimmed.is_empty() {
             continue;
@@ -155,5 +155,120 @@ fn speaker_from_energy(frames: &[EnergyFrame], start_ms: i64, end_ms: i64) -> St
         "Other".into()
     } else {
         "You".into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- Token filtering tests ---
+
+    /// Simulates the segment text cleaning logic from transcribe().
+    fn clean_segment_text(text: &str) -> Option<String> {
+        let cleaned = text.replace("[SPEAKER_TURN]", "").replace("[BLANK_AUDIO]", "");
+        let trimmed = cleaned.trim().to_string();
+        if trimmed.is_empty() { None } else { Some(trimmed) }
+    }
+
+    #[test]
+    fn blank_audio_token_is_filtered() {
+        assert_eq!(clean_segment_text("[BLANK_AUDIO]"), None);
+    }
+
+    #[test]
+    fn speaker_turn_token_is_filtered() {
+        assert_eq!(clean_segment_text("[SPEAKER_TURN]"), None);
+    }
+
+    #[test]
+    fn combined_tokens_are_filtered() {
+        assert_eq!(clean_segment_text("[SPEAKER_TURN] [BLANK_AUDIO]"), None);
+    }
+
+    #[test]
+    fn real_text_with_tokens_preserves_text() {
+        assert_eq!(
+            clean_segment_text("[SPEAKER_TURN] Hello world"),
+            Some("Hello world".into())
+        );
+    }
+
+    #[test]
+    fn real_text_preserved() {
+        assert_eq!(
+            clean_segment_text(" Hello, how are you? "),
+            Some("Hello, how are you?".into())
+        );
+    }
+
+    #[test]
+    fn whitespace_only_is_filtered() {
+        assert_eq!(clean_segment_text("   "), None);
+    }
+
+    // --- Speaker energy tests ---
+
+    fn make_energy_frames(pairs: &[(f32, f32)]) -> Vec<EnergyFrame> {
+        pairs.iter().enumerate().map(|(i, &(mic, sys))| EnergyFrame {
+            time_ms: (i * 100) as i64,
+            mic_rms: mic,
+            sys_rms: sys,
+        }).collect()
+    }
+
+    #[test]
+    fn speaker_from_energy_returns_you_when_system_silent() {
+        let frames = make_energy_frames(&[
+            (0.5, 0.0), (0.6, 0.0), (0.4, 0.0),
+        ]);
+        assert_eq!(speaker_from_energy(&frames, 0, 300), "You");
+    }
+
+    #[test]
+    fn speaker_from_energy_returns_other_when_mic_silent() {
+        let frames = make_energy_frames(&[
+            (0.0, 0.5), (0.0, 0.6), (0.0, 0.4),
+        ]);
+        assert_eq!(speaker_from_energy(&frames, 0, 300), "Other");
+    }
+
+    #[test]
+    fn speaker_from_energy_returns_you_when_mic_dominant() {
+        // Baseline: mic=0.3, sys=0.3. Segment: mic spikes more than sys.
+        let frames = make_energy_frames(&[
+            (0.3, 0.3), (0.3, 0.3), (0.3, 0.3), // baseline
+            (0.3, 0.3), (0.3, 0.3),
+            (0.8, 0.35), (0.9, 0.3), (0.7, 0.32), // mic spike
+        ]);
+        // Query the spike region (500-800ms)
+        assert_eq!(speaker_from_energy(&frames, 500, 800), "You");
+    }
+
+    #[test]
+    fn speaker_from_energy_returns_other_when_system_dominant() {
+        // Baseline: mic=0.3, sys=0.3. Segment: sys spikes more than mic.
+        let frames = make_energy_frames(&[
+            (0.3, 0.3), (0.3, 0.3), (0.3, 0.3), // baseline
+            (0.3, 0.3), (0.3, 0.3),
+            (0.35, 0.8), (0.3, 0.9), (0.32, 0.7), // sys spike
+        ]);
+        assert_eq!(speaker_from_energy(&frames, 500, 800), "Other");
+    }
+
+    #[test]
+    fn speaker_from_energy_returns_you_when_no_frames_in_range() {
+        let frames = make_energy_frames(&[(0.5, 0.5)]);
+        // Query range outside available frames
+        assert_eq!(speaker_from_energy(&frames, 5000, 6000), "You");
+    }
+
+    #[test]
+    fn speaker_from_energy_both_silent_returns_you() {
+        let frames = make_energy_frames(&[
+            (0.0, 0.0), (0.0, 0.0), (0.0, 0.0),
+        ]);
+        // Both channels silent → global_sys_avg < 1e-4 → "You"
+        assert_eq!(speaker_from_energy(&frames, 0, 300), "You");
     }
 }

--- a/src/hooks/useRecording.ts
+++ b/src/hooks/useRecording.ts
@@ -24,6 +24,7 @@ export interface UseRecordingReturn {
   meetingId: number | null;
   elapsedSeconds: number;
   error: string | null;
+  silenceWarning: boolean;
   startRecording: (micDeviceId?: string) => Promise<void>;
   stopRecording: () => Promise<void>;
   pauseRecording: () => Promise<void>;
@@ -35,6 +36,7 @@ export function useRecording(options?: UseRecordingOptions): UseRecordingReturn 
   const [meetingId, setMeetingId] = useState<number | null>(null);
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const [error, setError] = useState<string | null>(null);
+  const [silenceWarning, setSilenceWarning] = useState(false);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   // Track whether this window initiated the action, to avoid double-processing events
   const localActionRef = useRef(false);
@@ -60,6 +62,7 @@ export function useRecording(options?: UseRecordingOptions): UseRecordingReturn 
     }
 
     setError(null);
+    setSilenceWarning(false);
     localActionRef.current = true;
     try {
       const result = await invoke<StartRecordingResult>("start_recording", {
@@ -210,6 +213,20 @@ export function useRecording(options?: UseRecordingOptions): UseRecordingReturn 
     };
   }, [syncStatusFromBackend]);
 
+  // Check for silent mic audio ~4s after recording starts
+  useEffect(() => {
+    if (status !== "recording" || !isTauri()) return;
+    const timer = setTimeout(async () => {
+      try {
+        const silent = await invoke<boolean>("check_silence_warning");
+        if (silent) setSilenceWarning(true);
+      } catch {
+        // Best effort only.
+      }
+    }, 4000);
+    return () => clearTimeout(timer);
+  }, [status]);
+
   useEffect(() => {
     return () => clearTimer();
   }, [clearTimer]);
@@ -219,6 +236,7 @@ export function useRecording(options?: UseRecordingOptions): UseRecordingReturn 
     meetingId,
     elapsedSeconds,
     error,
+    silenceWarning,
     startRecording,
     stopRecording,
     pauseRecording,

--- a/src/overlay/OverlayApp.tsx
+++ b/src/overlay/OverlayApp.tsx
@@ -49,6 +49,7 @@ export default function OverlayApp() {
           elapsedSeconds={recording.elapsedSeconds}
           meetings={meetings}
           error={recording.error}
+          silenceWarning={recording.silenceWarning}
           onCollapse={handleCollapse}
           onStartRecording={recording.startRecording}
           onStopRecording={recording.stopRecording}
@@ -60,6 +61,7 @@ export default function OverlayApp() {
           status={recording.status}
           elapsedSeconds={recording.elapsedSeconds}
           meetings={meetings}
+          silenceWarning={recording.silenceWarning}
           onExpand={handleExpand}
           onStartRecording={recording.startRecording}
           onStopRecording={recording.stopRecording}

--- a/src/overlay/components/OverlayExpanded.tsx
+++ b/src/overlay/components/OverlayExpanded.tsx
@@ -17,6 +17,7 @@ interface Props {
   elapsedSeconds: number;
   meetings: DetectedMeeting[];
   error: string | null;
+  silenceWarning?: boolean;
   onCollapse: () => void;
   onStartRecording: (micDeviceId?: string) => Promise<void>;
   onStopRecording: () => Promise<void>;
@@ -39,6 +40,7 @@ export default function OverlayExpanded({
   elapsedSeconds,
   meetings,
   error,
+  silenceWarning,
   onCollapse,
   onStartRecording,
   onStopRecording,
@@ -99,6 +101,14 @@ export default function OverlayExpanded({
           {status === "paused" && (
             <div className="mt-1 text-xs text-yellow-400">Paused</div>
           )}
+        </div>
+      )}
+
+      {/* Silence warning */}
+      {silenceWarning && (
+        <div className="mx-4 mb-2 rounded-lg bg-yellow-500/15 px-3 py-2 text-xs text-yellow-300">
+          <span className="font-medium">No audio detected.</span>{" "}
+          Check your microphone permissions and selected device.
         </div>
       )}
 

--- a/src/overlay/components/OverlayPill.tsx
+++ b/src/overlay/components/OverlayPill.tsx
@@ -16,6 +16,7 @@ interface Props {
   status: RecordingStatus;
   elapsedSeconds: number;
   meetings: DetectedMeeting[];
+  silenceWarning?: boolean;
   onExpand: () => void;
   onStartRecording: (micDeviceId?: string) => Promise<void>;
   onStopRecording: () => Promise<void>;
@@ -37,6 +38,7 @@ function formatTime(seconds: number): string {
 export default function OverlayPill({
   status,
   elapsedSeconds,
+  silenceWarning,
   onExpand,
   onStartRecording,
   onStopRecording,
@@ -170,7 +172,7 @@ export default function OverlayPill({
             <>
               {/* Recording dot + timer */}
               <span className="flex items-center gap-1 shrink-0">
-                <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-red-500 animate-pulse" />
+                <span className={`h-1.5 w-1.5 shrink-0 rounded-full animate-pulse ${silenceWarning ? "bg-yellow-400" : "bg-red-500"}`} />
                 <span className="font-mono text-[10px] font-semibold text-text-primary tabular-nums whitespace-nowrap">
                   {formatTime(elapsedSeconds)}
                 </span>


### PR DESCRIPTION
## Summary

Users reported transcripts containing only `[BLANK_AUDIO]` tokens, caused by silent audio recordings (typically from permission issues on macOS where the stream delivers zero-filled buffers). This fix adds comprehensive silence detection across the recording and transcription pipeline.

## Changes

- **Real-time detection**: Monitors mic RMS after 3 seconds, sets flag to warn frontend
- **Frontend warnings**: Yellow banner in overlay and status indicator when silence detected
- **Pre-transcription validation**: Fails transcription gracefully with helpful error if audio is silent
- **Token filtering**: Strips `[BLANK_AUDIO]` tokens from Whisper output as safety net
- **Comprehensive testing**: 36 unit/integration tests validate silence detection, speaker diarization, audio encoding, and resampling

## Verification

All tests passing. Debug build successful. Tested with mock silent audio: warning appears at 4-second mark and transcription fails with actionable error message directing users to check microphone permissions.